### PR TITLE
FIX(Webpack): Wrong .babelrc file

### DIFF
--- a/generators/webpack/configs/.babelrc.config.js
+++ b/generators/webpack/configs/.babelrc.config.js
@@ -1,0 +1,32 @@
+module.exports = function render(contents, filename, options) {
+  const json = {
+    "presets": [],
+    "plugins": [
+      "@babel/plugin-proposal-object-rest-spread",
+    ]
+  };
+
+  if (options.typescript) {
+    json.presets.push("@babel/typescript");
+  } else {
+    json.presets.push(["@babel/preset-env", {
+      "forceAllTransforms": true,
+      "modules": false
+    }]);
+  }
+
+  if (options.react) {
+    json.presets.push("@babel/preset-react");
+    json.plugins.push("react-hot-loader/babel")
+  }
+
+  if (options.jest) {
+    json.env = {
+      "test": {
+        "plugins": ["@babel/plugin-transform-modules-commonjs"]
+      }
+    }
+  }
+
+  return JSON.stringify(json, null, 2);
+}

--- a/generators/webpack/index.js
+++ b/generators/webpack/index.js
@@ -187,10 +187,15 @@ module.exports = class extends Generator {
       {options: this.props, name: this.options.name}
     );
 
-    this.fs.copyTpl(
+    const renderBabelrc = require('./configs/.babelrc.config.js');
+    this.fs.copy(
       this.templatePath('.babelrc'),
       this.destinationPath('.babelrc'),
-      {options: this.props}
+      {
+        process: (contents, filename) => {
+          return renderBabelrc(contents, filename, this.props);
+        }
+      }
     );
 
     this.fs.copyTpl(

--- a/generators/webpack/templates/.babelrc
+++ b/generators/webpack/templates/.babelrc
@@ -1,21 +1,4 @@
 {
-  "presets": [
-      <% if (options.typescript) { %>
-        "@babel/typescript"
-      <% } else { %>
-      "@babel/preset-env",
-      {
-        "forceAllTransforms": true,
-        "modules": false
-      }<% } %>
-      <% if (options.react) { %>,
-        "@babel/preset-react"
-      <% } %>
-  ],
-  "plugins": ["@babel/plugin-proposal-object-rest-spread"<% if (options.react) { %> , "react-hot-loader/babel"<% } %>]<% if (options.jest) { %>,
-  "env": {
-    "test": {
-      "plugins": ["@babel/plugin-transform-modules-commonjs"]
-    }
-  }<% } %>
+  "presets": [],
+  "plugins": []
 }


### PR DESCRIPTION
# This PR is solving issue #33 

## Major Feature Introduced

**It provides a new way to render templates using custom JavaScript function instead of `ejs`.**

It is very simple to do so.
Instead of using `this.fs.copyTpl`, just use `this.fs.copy` with a `process` in options.

```js
    const renderBabelrc = require('./configs/.babelrc.config.js');
    this.fs.copy(
      this.templatePath('.babelrc'),
      this.destinationPath('.babelrc'),
      {
        process: (contents, filename) => {
          return renderBabelrc(contents, filename, this.props);
        }
      }
    );
```

## The fixed version of `.babelrc`:

### TypeScript

```
{
  "presets": [
    "@babel/typescript",
    "@babel/preset-react"
  ],
  "plugins": [
    "@babel/plugin-proposal-object-rest-spread",
    "react-hot-loader/babel"
  ],
  "env": {
    "test": {
      "plugins": [
        "@babel/plugin-transform-modules-commonjs"
      ]
    }
  }
}
```

### Non-TypeScript

```
{
  "presets": [
    [
      "@babel/preset-env",
      {
        "forceAllTransforms": true,
        "modules": false
      }
    ],
    "@babel/preset-react"
  ],
  "plugins": [
    "@babel/plugin-proposal-object-rest-spread",
    "react-hot-loader/babel"
  ],
  "env": {
    "test": {
      "plugins": [
        "@babel/plugin-transform-modules-commonjs"
      ]
    }
  }
}
```